### PR TITLE
Fix js parameter passing

### DIFF
--- a/local/chatbot/lib.php
+++ b/local/chatbot/lib.php
@@ -19,8 +19,10 @@ function local_chatbot_before_footer() {
     }
 
     $coursename = isset($COURSE->fullname) ? $COURSE->fullname : '';
-    $PAGE->requires->js_call_amd('local_chatbot/chatbot', 'init', [
+    // js_call_amd expects an array of arguments. Pass a single options object
+    // so the JS init function receives one parameter with userid and coursename.
+    $PAGE->requires->js_call_amd('local_chatbot/chatbot', 'init', [[
         'userid' => $USER->id,
         'coursename' => $coursename
-    ]);
+    ]]);
 }


### PR DESCRIPTION
## Summary
- ensure js_call_amd passes an options object

## Testing
- `php -l local/chatbot/lib.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fd87a5d8832985a4df9cbc3e06b2