### PR TITLE
Add student enable/disable management for chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This plugin adds a simple chat icon to Moodle pages so selected users can intera
 1. Zip the `local` directory into `chatbot.zip` so that the resulting archive contains the `chatbot` folder inside `local/`.
 2. Log in as an administrator and navigate to **Site administration > Plugins > Install plugins**.
 3. Upload `chatbot.zip` and follow the on‑screen instructions to complete the installation.
-4. After installation go to **Site administration > Plugins > Local plugins > Chatbot** to configure which users can access the chatbot.
+4. After installation go to **Site administration > Plugins > Local plugins > Chatbot** to manage which students can access the chatbot.
 
 ## Configuration
 
-- **Enabled user IDs** – Provide a comma‑separated list of Moodle user IDs that should see the chat icon. Leave this field empty to enable the chatbot for all authenticated users.
+Use the management page to search for students and enable or disable the chatbot for each of them. Only students marked as enabled will see the chat icon.
 
 ## Usage
 

--- a/local/chatbot/db/install.xml
+++ b/local/chatbot/db/install.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="local/chatbot/db" VERSION="2024071600" COMMENT="Install XML for chatbot plugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <TABLES>
+    <TABLE NAME="student_chatbots" COMMENT="Users enabled for chatbot">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+        <FIELD NAME="enabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="userid_unique" TYPE="unique" FIELDS="userid"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/local/chatbot/db/upgrade.php
+++ b/local/chatbot/db/upgrade.php
@@ -1,0 +1,29 @@
+<?php
+function xmldb_local_chatbot_upgrade($oldversion) {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2025070206) {
+        // Define table student_chatbots to be created.
+        $table = new xmldb_table('student_chatbots');
+
+        // Adding fields.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('enabled', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+
+        // Adding keys to table.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('userid_unique', XMLDB_KEY_UNIQUE, ['userid']);
+
+        // Conditionally launch create table for student_chatbots.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        upgrade_plugin_savepoint(true, 2025070206, 'local', 'chatbot');
+    }
+
+    return true;
+}

--- a/local/chatbot/lang/en/local_chatbot.php
+++ b/local/chatbot/lang/en/local_chatbot.php
@@ -1,7 +1,8 @@
 <?php
 defined('MOODLE_INTERNAL') || die();
 $string['pluginname'] = 'Chatbot';
-$string['enabledusers'] = 'Enabled user IDs';
-$string['enabledusers_desc'] = 'Comma separated list of user IDs allowed to use the chatbot. Leave blank to enable for all users.';
+$string['enable'] = 'Enable Chatbot';
+$string['disable'] = 'Disable Chatbot';
+$string['search'] = 'Search';
 $string['send'] = 'Send';
 $string['typehere'] = 'Type your message...';

--- a/local/chatbot/lib.php
+++ b/local/chatbot/lib.php
@@ -10,12 +10,10 @@ function local_chatbot_before_footer() {
         return;
     }
 
-    $enabled = get_config('local_chatbot', 'enabledusers');
-    if (!empty($enabled)) {
-        $ids = array_map('intval', array_map('trim', explode(',', $enabled)));
-        if (!in_array($USER->id, $ids)) {
-            return;
-        }
+    global $DB;
+    $record = $DB->get_record('student_chatbots', ['userid' => $USER->id]);
+    if (!$record || !$record->enabled) {
+        return;
     }
 
     $coursename = isset($COURSE->fullname) ? $COURSE->fullname : '';

--- a/local/chatbot/manage.php
+++ b/local/chatbot/manage.php
@@ -1,0 +1,87 @@
+<?php
+require_once(__DIR__ . '/../../config.php');
+
+require_login();
+$context = context_system::instance();
+require_capability('moodle/site:config', $context);
+
+$search = optional_param('search', '', PARAM_RAW);
+$action = optional_param('action', '', PARAM_ALPHA);
+$userid = optional_param('userid', 0, PARAM_INT);
+
+if ($action && confirm_sesskey() && $userid) {
+    $record = $DB->get_record('student_chatbots', ['userid' => $userid]);
+    if ($action === 'enable') {
+        if ($record) {
+            $record->enabled = 1;
+            $DB->update_record('student_chatbots', $record);
+        } else {
+            $DB->insert_record('student_chatbots', (object)[
+                'userid' => $userid,
+                'enabled' => 1
+            ]);
+        }
+    } else if ($action === 'disable') {
+        if ($record) {
+            $record->enabled = 0;
+            $DB->update_record('student_chatbots', $record);
+        } else {
+            $DB->insert_record('student_chatbots', (object)[
+                'userid' => $userid,
+                'enabled' => 0
+            ]);
+        }
+    }
+    redirect(new moodle_url('/local/chatbot/manage.php', ['search' => $search]));
+}
+
+$url = new moodle_url('/local/chatbot/manage.php', ['search' => $search]);
+$PAGE->set_url($url);
+$PAGE->set_context($context);
+$PAGE->set_heading(get_string('pluginname', 'local_chatbot'));
+
+$usersql = "SELECT id, firstname, lastname, email FROM {user} WHERE deleted=0";
+$params = [];
+
+if ($search !== '') {
+    $like = '%' . $search . '%';
+    $usersql .= " AND (".$DB->sql_like('firstname', ':s1')." OR "
+                      .$DB->sql_like('lastname', ':s2')." OR "
+                      .$DB->sql_like('email', ':s3').")";
+    $params['s1'] = $like;
+    $params['s2'] = $like;
+    $params['s3'] = $like;
+}
+
+$users = $DB->get_records_sql($usersql . ' ORDER BY lastname, firstname', $params);
+
+echo $OUTPUT->header();
+
+echo html_writer::start_tag('form', ['method' => 'get', 'action' => new moodle_url('/local/chatbot/manage.php')]);
+echo html_writer::tag('input', '', ['type' => 'text', 'name' => 'search', 'value' => $search, 'placeholder' => get_string('search')]);
+echo html_writer::empty_tag('input', ['type' => 'submit', 'value' => get_string('search')]);
+echo html_writer::end_tag('form');
+
+$table = new html_table();
+$table->head = ['ID', 'Name', 'Email', ''];
+
+foreach ($users as $user) {
+    $record = $DB->get_record('student_chatbots', ['userid' => $user->id]);
+    $enabled = $record && $record->enabled;
+    $buttonurl = new moodle_url('/local/chatbot/manage.php', [
+        'userid' => $user->id,
+        'action' => $enabled ? 'disable' : 'enable',
+        'search' => $search,
+        'sesskey' => sesskey()
+    ]);
+    $button = html_writer::tag('a', $enabled ? get_string('disable') : get_string('enable'), [
+        'href' => $buttonurl,
+        'class' => 'btn '.($enabled ? 'btn-danger' : 'btn-primary')
+    ]);
+    $name = fullname($user);
+    $table->data[] = [$user->id, $name, $user->email, $button];
+}
+
+echo html_writer::table($table);
+
+echo $OUTPUT->footer();

--- a/local/chatbot/settings.php
+++ b/local/chatbot/settings.php
@@ -2,9 +2,5 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
-    $settings = new admin_settingpage('local_chatbot', get_string('pluginname', 'local_chatbot'));
-    $settings->add(new admin_setting_configtext('local_chatbot/enabledusers',
-        get_string('enabledusers', 'local_chatbot'),
-        get_string('enabledusers_desc', 'local_chatbot'), '', PARAM_TEXT));
-    $ADMIN->add('localplugins', $settings);
+    $ADMIN->add('localplugins', new admin_externalpage('local_chatbot', get_string('pluginname', 'local_chatbot'), new moodle_url('/local/chatbot/manage.php')));
 }

--- a/local/chatbot/version.php
+++ b/local/chatbot/version.php
@@ -2,5 +2,5 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_chatbot';
-$plugin->version = 2025070205;
+$plugin->version = 2025070206;
 $plugin->requires = 2019052000; // Moodle 3.7.


### PR DESCRIPTION
## Summary
- create `student_chatbots` table and upgrade script
- add management page to search students and enable or disable chatbot access
- replace settings page with link to management UI
- check student enablement in `before_footer` callback
- update strings and docs

## Testing
- `php -l local/chatbot/manage.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68660c01c79083298b795c62fdbd7f26