### PR TITLE
Improve DB table upgrade handling

### DIFF
--- a/local/chatbot/db/upgrade.php
+++ b/local/chatbot/db/upgrade.php
@@ -4,25 +4,48 @@ function xmldb_local_chatbot_upgrade($oldversion) {
 
     $dbman = $DB->get_manager();
 
-    if ($oldversion < 2025070206) {
-        // Define table student_chatbots to be created.
+    if ($oldversion < 2025070207) {
+        // Define table student_chatbots.
         $table = new xmldb_table('student_chatbots');
 
-        // Adding fields.
-        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
-        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('enabled', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+        // Define all fields of the table.
+        $id      = new xmldb_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $userid  = new xmldb_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $enabled = new xmldb_field('enabled', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
 
-        // Adding keys to table.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
-        $table->add_key('userid_unique', XMLDB_KEY_UNIQUE, ['userid']);
+        // Define keys.
+        $primarykey = new xmldb_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $uniqueuserid = new xmldb_key('userid_unique', XMLDB_KEY_UNIQUE, ['userid']);
 
-        // Conditionally launch create table for student_chatbots.
         if (!$dbman->table_exists($table)) {
+            // Table does not exist, create it with all fields and keys.
+            $table->add_field($id);
+            $table->add_field($userid);
+            $table->add_field($enabled);
+            $table->add_key($primarykey);
+            $table->add_key($uniqueuserid);
             $dbman->create_table($table);
+        } else {
+            // Table exists. Ensure required fields and keys exist.
+            if (!$dbman->field_exists($table, $id)) {
+                $dbman->add_field($table, $id);
+            }
+            if (!$dbman->field_exists($table, $userid)) {
+                $dbman->add_field($table, $userid);
+            }
+            if (!$dbman->field_exists($table, $enabled)) {
+                $dbman->add_field($table, $enabled);
+            }
+
+            if (!$dbman->key_exists($table, $primarykey)) {
+                $dbman->add_key($table, $primarykey);
+            }
+            if (!$dbman->key_exists($table, $uniqueuserid)) {
+                $dbman->add_key($table, $uniqueuserid);
+            }
         }
 
-        upgrade_plugin_savepoint(true, 2025070206, 'local', 'chatbot');
+        upgrade_plugin_savepoint(true, 2025070207, 'local', 'chatbot');
     }
 
     return true;

--- a/local/chatbot/version.php
+++ b/local/chatbot/version.php
@@ -2,5 +2,5 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_chatbot';
-$plugin->version = 2025070206;
+$plugin->version = 2025070207;
 $plugin->requires = 2019052000; // Moodle 3.7.


### PR DESCRIPTION
## Summary
- ensure database table creation handles both new installs and upgrades safely
- bump plugin version

## Testing
- `php -l local/chatbot/db/upgrade.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e158e3a083299684abaa629c7ef0