### PR TITLE
Fix session ID persistence

### DIFF
--- a/local/chatbot/chatapi.php
+++ b/local/chatbot/chatapi.php
@@ -16,7 +16,11 @@ $message = required_param('message', PARAM_RAW);
 $userid = $USER->id;
 
 $interactionid = (string)$userid;
-$sessionid = uuid_v4();
+$sessionid = $SESSION->chatbot_sessionid ?? null;
+if (!$sessionid) {
+    $sessionid = uuid_v4();
+    $SESSION->chatbot_sessionid = $sessionid;
+}
 $now = microtime(true);
 $created = gmdate('Y-m-d\TH:i:s.', (int)$now) . sprintf('%06d', ($now - floor($now)) * 1e6);
 


### PR DESCRIPTION
## Summary
- persist `session_id` across requests

## Testing
- `php -l local/chatbot/chatapi.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b50eec98483298c1debb70dc7591e