### PR TITLE
Open chat window by default for enabled users

### DIFF
--- a/local/chatbot/templates/chatbox.mustache
+++ b/local/chatbot/templates/chatbox.mustache
@@ -1,7 +1,7 @@
 <div id="chatbot-icon" data-region="chatbot-icon">
     <img src="{{iconurl}}" alt="Chatbot" class="chatbot-icon-img" />
 </div>
-<div id="chatbot-window" class="hidden" data-region="chatbot-window">
+<div id="chatbot-window" data-region="chatbot-window">
     <div id="chatbot-context"></div>
     <div id="chatbot-credits"></div>
     <div id="chatbot-messages" data-region="chatbot-messages"></div>


### PR DESCRIPTION
## Summary
- Ensure the chatbot window is visible immediately when the plugin is enabled for a user.

## Testing
- `npm test` (fails: could not read package.json)
- `phpunit` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68ac4df2a0cc8329828cd1f97c1fd8d3